### PR TITLE
added docker stubs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# This is just a stub, not fully working yet, but general stub to dockerise components
+
+FROM lcasuol/lcas-docker:xenial-base
+
+WORKDIR workspace/src
+
+COPY . rasberry_data_capture
+
+RUN apt-get update \
+  && rosdep update \
+  && rosdep install --from-paths rasberry_data_capture -i -y
+
+#RUN apt-get install ros-kinetic-catkin
+#WORKDIR workspace
+#RUN catkin_make

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,18 @@ FROM lcasuol/lcas-docker:xenial-base
 
 WORKDIR workspace/src
 
+
+RUN apt-get update; apt-get dist-upgrade -y; \
+  rosdep update 
 COPY . rasberry_data_capture
-
-RUN apt-get update \
-  && rosdep update \
-  && rosdep install --from-paths rasberry_data_capture -i -y
-
+RUN rosdep install --from-paths rasberry_data_capture -i -y
+RUN bash -c 'source /opt/ros/kinetic/setup.bash; \
+    cd /workspace; catkin_make; \
+'
+ENTRYPOINT bash -c 'cd /workspace/src/rasberry_data_capture; \
+  source /workspace/devel/setup.bash; \
+  ./entry-point.sh; \
+'
 #RUN apt-get install ros-kinetic-catkin
 #WORKDIR workspace
 #RUN catkin_make

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,19 +4,19 @@ version: '3.1'
 services:
 
   # if we'd want to run the actual capture in docker as well...
-  #rasberry_data_capture:
-  #  build: .
-  #  devices:
-    # allow container to access USB0
-  #  - "/dev/ttyUSB0:/dev/ttyUSB0"
+  rasberry_data_capture:
+    image: lcasuol/rasberry_data_capture:latest
+    build: .
+    privileged: true
+    network_mode: "host"
 
   mongo:
     image: mongo:4.2
     restart: always
-    ports:
-      - 27018:27017
+    network_mode: "host"
     volumes:
       - /srv/mongo/db:/data/db
+    command: --port 27018
     environment:
       MONGO_INITDB_ROOT_USERNAME: root
       MONGO_INITDB_ROOT_PASSWORD: b7d7e9d16bef48e4cb78353214792814
@@ -24,10 +24,11 @@ services:
   mongo-express:
     image: mongo-express
     restart: always
-    ports:
-      - 8081:8081
+    network_mode: "host"
     environment:
+      ME_CONFIG_MONGODB_PORT: 27018
       ME_CONFIG_MONGODB_ADMINUSERNAME: root
+      ME_CONFIG_MONGODB_SERVER: localhost
       ME_CONFIG_MONGODB_ADMINPASSWORD: b7d7e9d16bef48e4cb78353214792814
       ME_CONFIG_BASICAUTH_USERNAME: rasberry
       ME_CONFIG_BASICAUTH_PASSWORD: 078c9cfbac66b9675de8935f7030ce06

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,33 @@
+# Use root/example as user/password credentials
+version: '3.1'
+
+services:
+
+  # if we'd want to run the actual capture in docker as well...
+  #rasberry_data_capture:
+  #  build: .
+  #  devices:
+    # allow container to access USB0
+  #  - "/dev/ttyUSB0:/dev/ttyUSB0"
+
+  mongo:
+    image: mongo:4.2
+    restart: always
+    ports:
+      - 27018:27017
+    volumes:
+      - /srv/mongo/db:/data/db
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: root
+      MONGO_INITDB_ROOT_PASSWORD: b7d7e9d16bef48e4cb78353214792814
+
+  mongo-express:
+    image: mongo-express
+    restart: always
+    ports:
+      - 8081:8081
+    environment:
+      ME_CONFIG_MONGODB_ADMINUSERNAME: root
+      ME_CONFIG_MONGODB_ADMINPASSWORD: b7d7e9d16bef48e4cb78353214792814
+      ME_CONFIG_BASICAUTH_USERNAME: rasberry
+      ME_CONFIG_BASICAUTH_PASSWORD: 078c9cfbac66b9675de8935f7030ce06

--- a/entry-point.sh
+++ b/entry-point.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# just a stub
+sleep 10
+echo "done"
+


### PR DESCRIPTION
This to include launching of docker containers for mongodb version 4.2

See https://github.com/LCAS/RASberry/issues/391 for preparations for this

running `docker-compose up` in the directory will pull the correct images and launch a mongodb instance, accessible at port `27018`, instead of the default `27017`. It also starts mongo_express as a lean web interface to look at it. Obviously, this is not the most secure, as the password are set in here, but we may change that (and as this is not meant for public deployment it's not a problem I would argue). Also relevant for @DreamingRaven.

This PR just adds docker configs and doesn't conflict with anything else.

